### PR TITLE
[Pre-PR] Pass picotool path to combine.sh

### DIFF
--- a/pico-client/CMakeLists.txt
+++ b/pico-client/CMakeLists.txt
@@ -39,6 +39,7 @@ add_custom_command(
     COMMAND ${CMAKE_SOURCE_DIR}/tools/combine.sh ${BOOTLOADER_ORIGIN} ${SLOT0_ORIGIN}
                                                  ${SLOT1_ORIGIN} ${SLOT2_ORIGIN}
                                                  ${CRC_SEED}
+                                                 $<TARGET_FILE:picotool>
     DEPENDS
         ${CMAKE_BINARY_DIR}/bootloader/bootloader.elf
         ${CMAKE_BINARY_DIR}/waterer/watering_slot0.elf

--- a/pico-client/tools/combine.sh
+++ b/pico-client/tools/combine.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+PICOTOOL="${6:-picotool}"
 
 BOOTLOADER_OFFSET=$(($1 - 0x10000000))
 SLOT0_OFFSET=$(($2 - 0x10000000))
@@ -150,8 +151,8 @@ extract_and_place_with_crc ${SLOT2_BIN} ${SLOT2_OFFSET} "slot2"
 
 # Convert to UF2 using picotool
 echo "Converting to UF2..."
-picotool uf2 convert ${COMBINED_BIN} ${COMBINED_UF2}
+"$PICOTOOL" uf2 convert ${COMBINED_BIN} ${COMBINED_UF2}
 
 # Get file info
 echo -e "\n=== Combined UF2 Info ==="
-picotool info ${COMBINED_UF2}
+"$PICOTOOL" info ${COMBINED_UF2}


### PR DESCRIPTION
This is a Pre-PR to Github Workflow pull request.

This PR updates CMakeLists.txt to pass the absolute path of the CMake-built picotool target to combine.sh, since it compiles correct verion of picotool.
This change allows all future CI/CD workflows not to worry about manually selecting correct picotool version for the combine.sh script.